### PR TITLE
feat(mic): added mic mute action

### DIFF
--- a/Actions/MediaMicMuteAction.cs
+++ b/Actions/MediaMicMuteAction.cs
@@ -1,0 +1,22 @@
+﻿using SuchByte.MacroDeck.ActionButton;
+using SuchByte.MacroDeck.Plugins;
+using SuchByte.MacroDeck.Logging;
+using SuchByte.MacroDeck.Variables;
+
+// ReSharper disable once CheckNamespace
+namespace MediaControls_Plugin; // Don't change because of compatibility
+
+public class MediaMicMuteAction : PluginAction
+{
+    private AudioManager microphoneManager = new AudioManager(Mode.Microphone);
+    public override string Name => "Media Microphone Mute";
+    public override string Description => "Mute microphone";
+    public override void Trigger(string clientId, ActionButton actionButton)
+    {
+        var state = microphoneManager.GetMasterVolumeMute();
+        var newState = !state;
+        MacroDeckLogger.Trace(PluginInstance.Main, "Is microphone muted: " + state + ", setting to: " + newState);
+        microphoneManager.SetMasterVolumeMute(newState);
+        VariableManager.SetValue("mic_muted", newState, VariableType.Bool, PluginInstance.Main, null);
+    }
+}

--- a/AudioManager.cs
+++ b/AudioManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Collections.Generic;
 // ReSharper disable SuspiciousTypeConversion.Global
 // ReSharper disable InconsistentNaming
 
@@ -7,25 +8,47 @@ using System.Runtime.InteropServices;
 
 namespace MediaControls_Plugin
 {
+    internal enum Mode
+    {
+        Microphone,
+        Speakers
+    }
     /// <summary>
     /// Controls audio using the Windows CoreAudio API
     /// from: http://stackoverflow.com/questions/14306048/controling-volume-mixer
     /// and: http://netcoreaudio.codeplex.com/
     /// </summary>
-    public static class AudioManager
+    public class AudioManager
     {
         #region Master Volume Manipulation
+
+        
+
+        private Direction direction;
+
+        internal AudioManager(Mode m)
+        {
+            switch (m)
+            {
+                case Mode.Microphone:
+                    direction = new Microphone();
+                    break;
+                case Mode.Speakers:
+                    direction = new Speakers();
+                    break;
+            }
+        }
 
         /// <summary>
         /// Gets the current master volume in scalar values (percentage)
         /// </summary>
         /// <returns>-1 in case of an error, if successful the value will be between 0 and 100</returns>
-        public static float GetMasterVolume()
+        public float GetMasterVolume()
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return -1;
 
@@ -45,12 +68,12 @@ namespace MediaControls_Plugin
         /// While the volume can be muted the <see cref="GetMasterVolume"/> will still return the pre-muted volume value.
         /// </summary>
         /// <returns>false if not muted, true if volume is muted</returns>
-        public static bool GetMasterVolumeMute()
+        public bool GetMasterVolumeMute()
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return false;
 
@@ -69,12 +92,12 @@ namespace MediaControls_Plugin
         /// Sets the master volume to a specific level
         /// </summary>
         /// <param name="newLevel">Value between 0 and 100 indicating the desired scalar value of the volume</param>
-        public static void SetMasterVolume(float newLevel)
+        public void SetMasterVolume(float newLevel)
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return;
 
@@ -93,12 +116,12 @@ namespace MediaControls_Plugin
         /// <param name="stepAmount">Value between -100 and 100 indicating the desired step amount. Use negative numbers to decrease
         /// the volume and positive numbers to increase it.</param>
         /// <returns>the new volume level assigned</returns>
-        public static float StepMasterVolume(float stepAmount)
+        public float StepMasterVolume(float stepAmount)
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return -1;
 
@@ -129,12 +152,12 @@ namespace MediaControls_Plugin
         /// Mute or unmute the master volume
         /// </summary>
         /// <param name="isMuted">true to mute the master volume, false to unmute</param>
-        public static void SetMasterVolumeMute(bool isMuted)
+        public void SetMasterVolumeMute(bool isMuted)
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return;
 
@@ -151,12 +174,12 @@ namespace MediaControls_Plugin
         /// Switches between the master volume mute states depending on the current state
         /// </summary>
         /// <returns>the current mute state, true if the volume was muted, false if unmuted</returns>
-        public static bool ToggleMasterVolumeMute()
+        public bool ToggleMasterVolumeMute()
         {
             IAudioEndpointVolume masterVol = null;
             try
             {
-                masterVol = GetMasterVolumeObject();
+                masterVol = CoreAudioAPI.GetMasterVolumeObject(direction);
                 if (masterVol == null)
                     return false;
 
@@ -173,36 +196,15 @@ namespace MediaControls_Plugin
             }
         }
 
-        private static IAudioEndpointVolume GetMasterVolumeObject()
-        {
-            IMMDeviceEnumerator deviceEnumerator = null;
-            IMMDevice speakers = null;
-            try
-            {
-                deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
-                deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out speakers);
-
-                Guid IID_IAudioEndpointVolume = typeof(IAudioEndpointVolume).GUID;
-                object o;
-                speakers.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out o);
-                IAudioEndpointVolume masterVol = (IAudioEndpointVolume)o;
-
-                return masterVol;
-            }
-            finally
-            {
-                if (speakers != null) Marshal.ReleaseComObject(speakers);
-                if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
-            }
-        }
+        
 
         #endregion
 
         #region Individual Application Volume Manipulation
 
-        public static float? GetApplicationVolume(int pid)
+        public float? GetApplicationVolume(int pid)
         {
-            ISimpleAudioVolume volume = GetVolumeObject(pid);
+            ISimpleAudioVolume volume = CoreAudioAPI.GetVolumeObject(direction, pid);
             if (volume == null)
                 return null;
 
@@ -212,9 +214,9 @@ namespace MediaControls_Plugin
             return level * 100;
         }
 
-        public static bool? GetApplicationMute(int pid)
+        public bool? GetApplicationMute(int pid)
         {
-            ISimpleAudioVolume volume = GetVolumeObject(pid);
+            ISimpleAudioVolume volume = CoreAudioAPI.GetVolumeObject(direction, pid);
             if (volume == null)
                 return null;
 
@@ -224,9 +226,9 @@ namespace MediaControls_Plugin
             return mute;
         }
 
-        public static void SetApplicationVolume(int pid, float level)
+        public void SetApplicationVolume(int pid, float level)
         {
-            ISimpleAudioVolume volume = GetVolumeObject(pid);
+            ISimpleAudioVolume volume = CoreAudioAPI.GetVolumeObject(direction, pid);
             if (volume == null)
                 return;
 
@@ -235,9 +237,9 @@ namespace MediaControls_Plugin
             Marshal.ReleaseComObject(volume);
         }
 
-        public static void SetApplicationMute(int pid, bool mute)
+        public void SetApplicationMute(int pid, bool mute)
         {
-            ISimpleAudioVolume volume = GetVolumeObject(pid);
+            ISimpleAudioVolume volume = CoreAudioAPI.GetVolumeObject(direction, pid);
             if (volume == null)
                 return;
 
@@ -246,377 +248,9 @@ namespace MediaControls_Plugin
             Marshal.ReleaseComObject(volume);
         }
 
-        private static ISimpleAudioVolume GetVolumeObject(int pid)
-        {
-            IMMDeviceEnumerator deviceEnumerator = null;
-            IAudioSessionEnumerator sessionEnumerator = null;
-            IAudioSessionManager2 mgr = null;
-            IMMDevice speakers = null;
-            try
-            {
-                // get the speakers (1st render + multimedia) device
-                deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
-                deviceEnumerator.GetDefaultAudioEndpoint(EDataFlow.eRender, ERole.eMultimedia, out speakers);
-
-                // activate the session manager. we need the enumerator
-                Guid IID_IAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;
-                object o;
-                speakers.Activate(ref IID_IAudioSessionManager2, 0, IntPtr.Zero, out o);
-                mgr = (IAudioSessionManager2)o;
-
-                // enumerate sessions for on this device
-                mgr.GetSessionEnumerator(out sessionEnumerator);
-                int count;
-                sessionEnumerator.GetCount(out count);
-
-                // search for an audio session with the required process-id
-                ISimpleAudioVolume volumeControl = null;
-                for (int i = 0; i < count; ++i)
-                {
-                    IAudioSessionControl2 ctl = null;
-                    try
-                    {
-                        sessionEnumerator.GetSession(i, out ctl);
-
-                        // NOTE: we could also use the app name from ctl.GetDisplayName()
-                        int cpid;
-                        ctl.GetProcessId(out cpid);
-
-                        if (cpid == pid)
-                        {
-                            volumeControl = ctl as ISimpleAudioVolume;
-                            break;
-                        }
-                    }
-                    finally
-                    {
-                        if (ctl != null) Marshal.ReleaseComObject(ctl);
-                    }
-                }
-
-                return volumeControl;
-            }
-            finally
-            {
-                if (sessionEnumerator != null) Marshal.ReleaseComObject(sessionEnumerator);
-                if (mgr != null) Marshal.ReleaseComObject(mgr);
-                if (speakers != null) Marshal.ReleaseComObject(speakers);
-                if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
-            }
-        }
+        
 
         #endregion
 
     }
-
-    #region Abstracted COM interfaces from Windows CoreAudio API
-
-    [ComImport]
-    [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
-    internal class MMDeviceEnumerator
-    {
-    }
-
-    internal enum EDataFlow
-    {
-        eRender,
-        eCapture,
-        eAll,
-        EDataFlow_enum_count
-    }
-
-    internal enum ERole
-    {
-        eConsole,
-        eMultimedia,
-        eCommunications,
-        ERole_enum_count
-    }
-
-    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IMMDeviceEnumerator
-    {
-        int NotImpl1();
-
-        [PreserveSig]
-        int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, out IMMDevice ppDevice);
-
-        // the rest is not implemented
-    }
-
-    [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IMMDevice
-    {
-        [PreserveSig]
-        int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
-
-        // the rest is not implemented
-    }
-
-    [Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IAudioSessionManager2
-    {
-        int NotImpl1();
-        int NotImpl2();
-
-        [PreserveSig]
-        int GetSessionEnumerator(out IAudioSessionEnumerator SessionEnum);
-
-        // the rest is not implemented
-    }
-
-    [Guid("E2F5BB11-0570-40CA-ACDD-3AA01277DEE8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IAudioSessionEnumerator
-    {
-        [PreserveSig]
-        int GetCount(out int SessionCount);
-
-        [PreserveSig]
-        int GetSession(int SessionCount, out IAudioSessionControl2 Session);
-    }
-
-    [Guid("87CE5498-68D6-44E5-9215-6DA47EF883D8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface ISimpleAudioVolume
-    {
-        [PreserveSig]
-        int SetMasterVolume(float fLevel, ref Guid EventContext);
-
-        [PreserveSig]
-        int GetMasterVolume(out float pfLevel);
-
-        [PreserveSig]
-        int SetMute(bool bMute, ref Guid EventContext);
-
-        [PreserveSig]
-        int GetMute(out bool pbMute);
-    }
-
-    [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    internal interface IAudioSessionControl2
-    {
-        // IAudioSessionControl
-        [PreserveSig]
-        int NotImpl0();
-
-        [PreserveSig]
-        int GetDisplayName([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
-
-        [PreserveSig]
-        int SetDisplayName([MarshalAs(UnmanagedType.LPWStr)] string Value, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
-
-        [PreserveSig]
-        int GetIconPath([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
-
-        [PreserveSig]
-        int SetIconPath([MarshalAs(UnmanagedType.LPWStr)] string Value, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
-
-        [PreserveSig]
-        int GetGroupingParam(out Guid pRetVal);
-
-        [PreserveSig]
-        int SetGroupingParam([MarshalAs(UnmanagedType.LPStruct)] Guid Override, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
-
-        [PreserveSig]
-        int NotImpl1();
-
-        [PreserveSig]
-        int NotImpl2();
-
-        // IAudioSessionControl2
-        [PreserveSig]
-        int GetSessionIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
-
-        [PreserveSig]
-        int GetSessionInstanceIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
-
-        [PreserveSig]
-        int GetProcessId(out int pRetVal);
-
-        [PreserveSig]
-        int IsSystemSoundsSession();
-
-        [PreserveSig]
-        int SetDuckingPreference(bool optOut);
-    }
-
-    // http://netcoreaudio.codeplex.com/SourceControl/latest#trunk/Code/CoreAudio/Interfaces/IAudioEndpointVolume.cs
-    [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-    public interface IAudioEndpointVolume
-    {
-        [PreserveSig]
-        int NotImpl1();
-
-        [PreserveSig]
-        int NotImpl2();
-
-        /// <summary>
-        /// Gets a count of the channels in the audio stream.
-        /// </summary>
-        /// <param name="channelCount">The number of channels.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetChannelCount(
-            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 channelCount);
-
-        /// <summary>
-        /// Sets the master volume level of the audio stream, in decibels.
-        /// </summary>
-        /// <param name="level">The new master volume level in decibels.</param>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int SetMasterVolumeLevel(
-            [In][MarshalAs(UnmanagedType.R4)] float level,
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Sets the master volume level, expressed as a normalized, audio-tapered value.
-        /// </summary>
-        /// <param name="level">The new master volume level expressed as a normalized value between 0.0 and 1.0.</param>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int SetMasterVolumeLevelScalar(
-            [In][MarshalAs(UnmanagedType.R4)] float level,
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Gets the master volume level of the audio stream, in decibels.
-        /// </summary>
-        /// <param name="level">The volume level in decibels.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetMasterVolumeLevel(
-            [Out][MarshalAs(UnmanagedType.R4)] out float level);
-
-        /// <summary>
-        /// Gets the master volume level, expressed as a normalized, audio-tapered value.
-        /// </summary>
-        /// <param name="level">The volume level expressed as a normalized value between 0.0 and 1.0.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetMasterVolumeLevelScalar(
-            [Out][MarshalAs(UnmanagedType.R4)] out float level);
-
-        /// <summary>
-        /// Sets the volume level, in decibels, of the specified channel of the audio stream.
-        /// </summary>
-        /// <param name="channelNumber">The channel number.</param>
-        /// <param name="level">The new volume level in decibels.</param>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int SetChannelVolumeLevel(
-            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
-            [In][MarshalAs(UnmanagedType.R4)] float level,
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Sets the normalized, audio-tapered volume level of the specified channel in the audio stream.
-        /// </summary>
-        /// <param name="channelNumber">The channel number.</param>
-        /// <param name="level">The new master volume level expressed as a normalized value between 0.0 and 1.0.</param>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int SetChannelVolumeLevelScalar(
-            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
-            [In][MarshalAs(UnmanagedType.R4)] float level,
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Gets the volume level, in decibels, of the specified channel in the audio stream.
-        /// </summary>
-        /// <param name="channelNumber">The zero-based channel number.</param>
-		/// <param name="level">The volume level in decibels.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetChannelVolumeLevel(
-            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
-            [Out][MarshalAs(UnmanagedType.R4)] out float level);
-
-        /// <summary>
-        /// Gets the normalized, audio-tapered volume level of the specified channel of the audio stream.
-        /// </summary>
-        /// <param name="channelNumber">The zero-based channel number.</param>
-		/// <param name="level">The volume level expressed as a normalized value between 0.0 and 1.0.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetChannelVolumeLevelScalar(
-            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
-            [Out][MarshalAs(UnmanagedType.R4)] out float level);
-
-        /// <summary>
-        /// Sets the muting state of the audio stream.
-        /// </summary>
-        /// <param name="isMuted">True to mute the stream, or false to unmute the stream.</param>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int SetMute(
-            [In][MarshalAs(UnmanagedType.Bool)] Boolean isMuted,
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Gets the muting state of the audio stream.
-        /// </summary>
-        /// <param name="isMuted">The muting state. True if the stream is muted, false otherwise.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetMute(
-            [Out][MarshalAs(UnmanagedType.Bool)] out Boolean isMuted);
-
-        /// <summary>
-        /// Gets information about the current step in the volume range.
-        /// </summary>
-        /// <param name="step">The current zero-based step index.</param>
-        /// <param name="stepCount">The total number of steps in the volume range.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetVolumeStepInfo(
-            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 step,
-            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 stepCount);
-
-        /// <summary>
-        /// Increases the volume level by one step.
-        /// </summary>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int VolumeStepUp(
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Decreases the volume level by one step.
-        /// </summary>
-        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int VolumeStepDown(
-            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
-
-        /// <summary>
-        /// Queries the audio endpoint device for its hardware-supported functions.
-        /// </summary>
-        /// <param name="hardwareSupportMask">A hardware support mask that indicates the capabilities of the endpoint.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int QueryHardwareSupport(
-            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 hardwareSupportMask);
-
-        /// <summary>
-        /// Gets the volume range of the audio stream, in decibels.
-        /// </summary>
-		/// <param name="volumeMin">The minimum volume level in decibels.</param>
-		/// <param name="volumeMax">The maximum volume level in decibels.</param>
-		/// <param name="volumeStep">The volume increment level in decibels.</param>
-        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
-        [PreserveSig]
-        int GetVolumeRange(
-            [Out][MarshalAs(UnmanagedType.R4)] out float volumeMin,
-            [Out][MarshalAs(UnmanagedType.R4)] out float volumeMax,
-            [Out][MarshalAs(UnmanagedType.R4)] out float volumeStep);
-    }
-
-    #endregion
 }

--- a/CoreAudioAPI.cs
+++ b/CoreAudioAPI.cs
@@ -1,0 +1,418 @@
+using System;
+using System.Runtime.InteropServices;
+// ReSharper disable SuspiciousTypeConversion.Global
+// ReSharper disable InconsistentNaming
+
+//Copied from https://gist.github.com/sverrirs/d099b34b7f72bb4fb386
+
+namespace MediaControls_Plugin
+{
+    #region Abstracted COM interfaces from Windows CoreAudio API
+    internal class Speakers : Direction {
+        public EDataFlow Flow => EDataFlow.eRender;
+        public ERole Role => ERole.eMultimedia;
+    }
+
+    internal class Microphone : Direction {
+        public EDataFlow Flow => EDataFlow.eCapture;
+        public ERole Role => ERole.eMultimedia;
+    }
+
+    internal interface Direction {
+        EDataFlow Flow { get; }
+        ERole Role { get; }
+    }
+
+    internal static class CoreAudioAPI {
+        public static IAudioEndpointVolume GetMasterVolumeObject(Direction dir)
+        {
+            IMMDeviceEnumerator deviceEnumerator = null;
+            IMMDevice speakers = null;
+            try
+            {
+                deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out speakers);
+
+                Guid IID_IAudioEndpointVolume = typeof(IAudioEndpointVolume).GUID;
+                object o;
+                speakers.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out o);
+                IAudioEndpointVolume masterVol = (IAudioEndpointVolume)o;
+
+                return masterVol;
+            }
+            finally
+            {
+                if (speakers != null) Marshal.ReleaseComObject(speakers);
+                if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
+            }
+        }
+
+        public static ISimpleAudioVolume GetVolumeObject(Direction dir, int pid)
+        {
+            IMMDeviceEnumerator deviceEnumerator = null;
+            IAudioSessionEnumerator sessionEnumerator = null;
+            IAudioSessionManager2 mgr = null;
+            IMMDevice speakers = null;
+            try
+            {
+                // get the speakers (1st render + multimedia) device
+                deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
+                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out speakers);
+
+                // activate the session manager. we need the enumerator
+                Guid IID_IAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;
+                object o;
+                speakers.Activate(ref IID_IAudioSessionManager2, 0, IntPtr.Zero, out o);
+                mgr = (IAudioSessionManager2)o;
+
+                // enumerate sessions for on this device
+                mgr.GetSessionEnumerator(out sessionEnumerator);
+                int count;
+                sessionEnumerator.GetCount(out count);
+
+                // search for an audio session with the required process-id
+                ISimpleAudioVolume volumeControl = null;
+                for (int i = 0; i < count; ++i)
+                {
+                    IAudioSessionControl2 ctl = null;
+                    try
+                    {
+                        sessionEnumerator.GetSession(i, out ctl);
+
+                        // NOTE: we could also use the app name from ctl.GetDisplayName()
+                        int cpid;
+                        ctl.GetProcessId(out cpid);
+
+                        if (cpid == pid)
+                        {
+                            volumeControl = ctl as ISimpleAudioVolume;
+                            break;
+                        }
+                    }
+                    finally
+                    {
+                        if (ctl != null) Marshal.ReleaseComObject(ctl);
+                    }
+                }
+
+                return volumeControl;
+            }
+            finally
+            {
+                if (sessionEnumerator != null) Marshal.ReleaseComObject(sessionEnumerator);
+                if (mgr != null) Marshal.ReleaseComObject(mgr);
+                if (speakers != null) Marshal.ReleaseComObject(speakers);
+                if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
+            }
+        }
+    }
+
+    [ComImport]
+    [Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")]
+    internal class MMDeviceEnumerator
+    {
+    }
+
+    internal enum EDataFlow
+    {
+        eRender,
+        eCapture,
+        eAll,
+        EDataFlow_enum_count
+    }
+
+    internal enum ERole
+    {
+        eConsole,
+        eMultimedia,
+        eCommunications,
+        ERole_enum_count
+    }
+
+    [Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IMMDeviceEnumerator
+    {
+        int NotImpl1();
+
+        [PreserveSig]
+        int GetDefaultAudioEndpoint(EDataFlow dataFlow, ERole role, out IMMDevice ppDevice);
+
+        // the rest is not implemented
+    }
+
+    [Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IMMDevice
+    {
+        [PreserveSig]
+        int Activate(ref Guid iid, int dwClsCtx, IntPtr pActivationParams, [MarshalAs(UnmanagedType.IUnknown)] out object ppInterface);
+
+        // the rest is not implemented
+    }
+
+    [Guid("77AA99A0-1BD6-484F-8BC7-2C654C9A9B6F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionManager2
+    {
+        int NotImpl1();
+        int NotImpl2();
+
+        [PreserveSig]
+        int GetSessionEnumerator(out IAudioSessionEnumerator SessionEnum);
+
+        // the rest is not implemented
+    }
+
+    [Guid("E2F5BB11-0570-40CA-ACDD-3AA01277DEE8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionEnumerator
+    {
+        [PreserveSig]
+        int GetCount(out int SessionCount);
+
+        [PreserveSig]
+        int GetSession(int SessionCount, out IAudioSessionControl2 Session);
+    }
+
+    [Guid("87CE5498-68D6-44E5-9215-6DA47EF883D8"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface ISimpleAudioVolume
+    {
+        [PreserveSig]
+        int SetMasterVolume(float fLevel, ref Guid EventContext);
+
+        [PreserveSig]
+        int GetMasterVolume(out float pfLevel);
+
+        [PreserveSig]
+        int SetMute(bool bMute, ref Guid EventContext);
+
+        [PreserveSig]
+        int GetMute(out bool pbMute);
+    }
+
+    [Guid("bfb7ff88-7239-4fc9-8fa2-07c950be9c6d"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    internal interface IAudioSessionControl2
+    {
+        // IAudioSessionControl
+        [PreserveSig]
+        int NotImpl0();
+
+        [PreserveSig]
+        int GetDisplayName([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int SetDisplayName([MarshalAs(UnmanagedType.LPWStr)] string Value, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
+
+        [PreserveSig]
+        int GetIconPath([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int SetIconPath([MarshalAs(UnmanagedType.LPWStr)] string Value, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
+
+        [PreserveSig]
+        int GetGroupingParam(out Guid pRetVal);
+
+        [PreserveSig]
+        int SetGroupingParam([MarshalAs(UnmanagedType.LPStruct)] Guid Override, [MarshalAs(UnmanagedType.LPStruct)] Guid EventContext);
+
+        [PreserveSig]
+        int NotImpl1();
+
+        [PreserveSig]
+        int NotImpl2();
+
+        // IAudioSessionControl2
+        [PreserveSig]
+        int GetSessionIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int GetSessionInstanceIdentifier([MarshalAs(UnmanagedType.LPWStr)] out string pRetVal);
+
+        [PreserveSig]
+        int GetProcessId(out int pRetVal);
+
+        [PreserveSig]
+        int IsSystemSoundsSession();
+
+        [PreserveSig]
+        int SetDuckingPreference(bool optOut);
+    }
+
+    // http://netcoreaudio.codeplex.com/SourceControl/latest#trunk/Code/CoreAudio/Interfaces/IAudioEndpointVolume.cs
+    [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IAudioEndpointVolume
+    {
+        [PreserveSig]
+        int NotImpl1();
+
+        [PreserveSig]
+        int NotImpl2();
+
+        /// <summary>
+        /// Gets a count of the channels in the audio stream.
+        /// </summary>
+        /// <param name="channelCount">The number of channels.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetChannelCount(
+            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 channelCount);
+
+        /// <summary>
+        /// Sets the master volume level of the audio stream, in decibels.
+        /// </summary>
+        /// <param name="level">The new master volume level in decibels.</param>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int SetMasterVolumeLevel(
+            [In][MarshalAs(UnmanagedType.R4)] float level,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Sets the master volume level, expressed as a normalized, audio-tapered value.
+        /// </summary>
+        /// <param name="level">The new master volume level expressed as a normalized value between 0.0 and 1.0.</param>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int SetMasterVolumeLevelScalar(
+            [In][MarshalAs(UnmanagedType.R4)] float level,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Gets the master volume level of the audio stream, in decibels.
+        /// </summary>
+        /// <param name="level">The volume level in decibels.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetMasterVolumeLevel(
+            [Out][MarshalAs(UnmanagedType.R4)] out float level);
+
+        /// <summary>
+        /// Gets the master volume level, expressed as a normalized, audio-tapered value.
+        /// </summary>
+        /// <param name="level">The volume level expressed as a normalized value between 0.0 and 1.0.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetMasterVolumeLevelScalar(
+            [Out][MarshalAs(UnmanagedType.R4)] out float level);
+
+        /// <summary>
+        /// Sets the volume level, in decibels, of the specified channel of the audio stream.
+        /// </summary>
+        /// <param name="channelNumber">The channel number.</param>
+        /// <param name="level">The new volume level in decibels.</param>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int SetChannelVolumeLevel(
+            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
+            [In][MarshalAs(UnmanagedType.R4)] float level,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Sets the normalized, audio-tapered volume level of the specified channel in the audio stream.
+        /// </summary>
+        /// <param name="channelNumber">The channel number.</param>
+        /// <param name="level">The new master volume level expressed as a normalized value between 0.0 and 1.0.</param>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int SetChannelVolumeLevelScalar(
+            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
+            [In][MarshalAs(UnmanagedType.R4)] float level,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Gets the volume level, in decibels, of the specified channel in the audio stream.
+        /// </summary>
+        /// <param name="channelNumber">The zero-based channel number.</param>
+		/// <param name="level">The volume level in decibels.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetChannelVolumeLevel(
+            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
+            [Out][MarshalAs(UnmanagedType.R4)] out float level);
+
+        /// <summary>
+        /// Gets the normalized, audio-tapered volume level of the specified channel of the audio stream.
+        /// </summary>
+        /// <param name="channelNumber">The zero-based channel number.</param>
+		/// <param name="level">The volume level expressed as a normalized value between 0.0 and 1.0.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetChannelVolumeLevelScalar(
+            [In][MarshalAs(UnmanagedType.U4)] UInt32 channelNumber,
+            [Out][MarshalAs(UnmanagedType.R4)] out float level);
+
+        /// <summary>
+        /// Sets the muting state of the audio stream.
+        /// </summary>
+        /// <param name="isMuted">True to mute the stream, or false to unmute the stream.</param>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int SetMute(
+            [In][MarshalAs(UnmanagedType.Bool)] Boolean isMuted,
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Gets the muting state of the audio stream.
+        /// </summary>
+        /// <param name="isMuted">The muting state. True if the stream is muted, false otherwise.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetMute(
+            [Out][MarshalAs(UnmanagedType.Bool)] out Boolean isMuted);
+
+        /// <summary>
+        /// Gets information about the current step in the volume range.
+        /// </summary>
+        /// <param name="step">The current zero-based step index.</param>
+        /// <param name="stepCount">The total number of steps in the volume range.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetVolumeStepInfo(
+            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 step,
+            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 stepCount);
+
+        /// <summary>
+        /// Increases the volume level by one step.
+        /// </summary>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int VolumeStepUp(
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Decreases the volume level by one step.
+        /// </summary>
+        /// <param name="eventContext">A user context value that is passed to the notification callback.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int VolumeStepDown(
+            [In][MarshalAs(UnmanagedType.LPStruct)] Guid eventContext);
+
+        /// <summary>
+        /// Queries the audio endpoint device for its hardware-supported functions.
+        /// </summary>
+        /// <param name="hardwareSupportMask">A hardware support mask that indicates the capabilities of the endpoint.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int QueryHardwareSupport(
+            [Out][MarshalAs(UnmanagedType.U4)] out UInt32 hardwareSupportMask);
+
+        /// <summary>
+        /// Gets the volume range of the audio stream, in decibels.
+        /// </summary>
+		/// <param name="volumeMin">The minimum volume level in decibels.</param>
+		/// <param name="volumeMax">The maximum volume level in decibels.</param>
+		/// <param name="volumeStep">The volume increment level in decibels.</param>
+        /// <returns>An HRESULT code indicating whether the operation passed of failed.</returns>
+        [PreserveSig]
+        int GetVolumeRange(
+            [Out][MarshalAs(UnmanagedType.R4)] out float volumeMin,
+            [Out][MarshalAs(UnmanagedType.R4)] out float volumeMax,
+            [Out][MarshalAs(UnmanagedType.R4)] out float volumeStep);
+    }
+
+    #endregion
+}

--- a/CoreAudioAPI.cs
+++ b/CoreAudioAPI.cs
@@ -27,22 +27,22 @@ namespace MediaControls_Plugin
         public static IAudioEndpointVolume GetMasterVolumeObject(Direction dir)
         {
             IMMDeviceEnumerator deviceEnumerator = null;
-            IMMDevice speakers = null;
+            IMMDevice device = null;
             try
             {
                 deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
-                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out speakers);
+                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out device);
 
                 Guid IID_IAudioEndpointVolume = typeof(IAudioEndpointVolume).GUID;
                 object o;
-                speakers.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out o);
+                device.Activate(ref IID_IAudioEndpointVolume, 0, IntPtr.Zero, out o);
                 IAudioEndpointVolume masterVol = (IAudioEndpointVolume)o;
 
                 return masterVol;
             }
             finally
             {
-                if (speakers != null) Marshal.ReleaseComObject(speakers);
+                if (device != null) Marshal.ReleaseComObject(device);
                 if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
             }
         }
@@ -52,17 +52,17 @@ namespace MediaControls_Plugin
             IMMDeviceEnumerator deviceEnumerator = null;
             IAudioSessionEnumerator sessionEnumerator = null;
             IAudioSessionManager2 mgr = null;
-            IMMDevice speakers = null;
+            IMMDevice device = null;
             try
             {
                 // get the speakers (1st render + multimedia) device
                 deviceEnumerator = (IMMDeviceEnumerator)(new MMDeviceEnumerator());
-                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out speakers);
+                deviceEnumerator.GetDefaultAudioEndpoint(dir.Flow, dir.Role, out device);
 
                 // activate the session manager. we need the enumerator
                 Guid IID_IAudioSessionManager2 = typeof(IAudioSessionManager2).GUID;
                 object o;
-                speakers.Activate(ref IID_IAudioSessionManager2, 0, IntPtr.Zero, out o);
+                device.Activate(ref IID_IAudioSessionManager2, 0, IntPtr.Zero, out o);
                 mgr = (IAudioSessionManager2)o;
 
                 // enumerate sessions for on this device
@@ -101,7 +101,7 @@ namespace MediaControls_Plugin
             {
                 if (sessionEnumerator != null) Marshal.ReleaseComObject(sessionEnumerator);
                 if (mgr != null) Marshal.ReleaseComObject(mgr);
-                if (speakers != null) Marshal.ReleaseComObject(speakers);
+                if (device != null) Marshal.ReleaseComObject(device);
                 if (deviceEnumerator != null) Marshal.ReleaseComObject(deviceEnumerator);
             }
         }

--- a/MediaControls Plugin.csproj
+++ b/MediaControls Plugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
     <RootNamespace>MediaControls_Plugin</RootNamespace>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Version>1.3.0</Version>


### PR DESCRIPTION
In this PR, I'm adding a feature to mute the user's microphone using the existing `AudioManager` class, which I had to slightly refactor. Now, users can add a new action "Media Microphone Mute", which will toggle the mic system-wide.

The AudioManager is now accepting the "Direction" argument, which determines which device is being managed: Speakers or Microphone.

The variable "mic_muted" is also being watched in the main loop, so once the mute status has changed, the variable will be updated as well, so the users have a way to connect app button status to the actual status of the mic (to avoid saying too much during a stressful game.. 😅)